### PR TITLE
Improve deployment configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,4 +47,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Deployment on Render
 
+Set the `VITE_API_URL` environment variable to the base URL of your backend when deploying.
+If it is not provided, API requests default to the same origin.
+
+Build the frontend and start the Express server with:
+
+```sh
+npm run build
+npm run serve
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "serve": "node backend/server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/frontend/src/services/pageService.ts
+++ b/frontend/src/services/pageService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const API_BASE = 'http://localhost:3001/api/pages';
+const API_ROOT = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '');
+const API_BASE = `${API_ROOT}/api/pages`;
 
 
 


### PR DESCRIPTION
## Summary
- allow base API URL to be configured with `VITE_API_URL`
- add `serve` script for production usage
- document Render deployment steps

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688081b3dc408332b136e154f7571d68