### PR TITLE
Improve deployment configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,4 +47,22 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Deployment on Render
 
+Follow these steps to deploy the app on [Render](https://render.com):
+
+1. Create a new **Web Service** from your repository.
+2. Set the **Root Directory** to `frontend` so Render runs commands in that folder.
+3. Set the **Build Command** to:
+   ```sh
+   npm run build
+   ```
+4. Set the **Start Command** to:
+   ```sh
+   npm run serve
+   ```
+5. Add an environment variable named `VITE_API_URL` with the base URL of your
+   backend (leave it blank to default to the same origin).
+6. (Optional) Set `MONGODB_URI` if your backend requires a custom MongoDB
+   connection string.
+7. Click **Create Web Service** to deploy.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "dev": "npm-run-all --parallel start backend",
     "start": "vite",
-    "backend": "cd backend && nodemon server.js",
+    "backend": "cd ../backend && nodemon server.js",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "serve": "node ../backend/server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/frontend/src/services/pageService.ts
+++ b/frontend/src/services/pageService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const API_BASE = 'http://localhost:3001/api/pages';
+const API_ROOT = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '');
+const API_BASE = `${API_ROOT}/api/pages`;
 
 
 


### PR DESCRIPTION
## Summary
- allow base API URL to be configured with `VITE_API_URL`
- add `serve` script for production usage
- document Render deployment steps
- fix path to backend scripts and clarify Render root directory

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm test` *(fails: Missing script: `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688081b3dc408332b136e154f7571d68