### PR TITLE
Fix frontend deployment and update url

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -68,5 +68,6 @@ app.get('*', (req, res) => {
 // Start server
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, '0.0.0.0', () => {
-  console.log(`🚀 Server running on port ${PORT}`);
+  console.log(`🚀 Server running on http://0.0.0.0:${PORT}`);
+  console.log(`📦 Serving frontend from: ${frontendPath}`);
 });

--- a/build.sh
+++ b/build.sh
@@ -8,9 +8,18 @@ cd frontend
 npm install
 echo "✅ Frontend dependencies installed"
 
-echo "🏗️  Building frontend..."
+echo "🏗️  Building frontend for production..."
 npm run build
 echo "✅ Frontend built successfully"
+
+# Verify build output
+if [ -d "dist" ]; then
+    echo "📦 Build output verified in frontend/dist"
+    ls -la dist/
+else
+    echo "❌ Build failed - no dist folder found"
+    exit 1
+fi
 
 cd ../backend
 echo "🔧 Installing backend dependencies..."
@@ -18,3 +27,4 @@ npm install
 echo "✅ Backend dependencies installed"
 
 echo "🚀 Build completed successfully!"
+echo "📁 Frontend build will be served from backend at /frontend/dist"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,15 +6,19 @@ import { componentTagger } from "lovable-tagger";
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
-    host: "::",
+    host: "0.0.0.0",
     port: 8080,
     proxy: {
       "/api": {
-        target: "http://localhost:3001", // assuming your Express server runs on port 3000
+        target: "http://localhost:3001",
         changeOrigin: true,
         secure: false,
       },
     },
+  },
+  preview: {
+    host: "0.0.0.0",
+    port: 4173,
   },
   build: {
     outDir: "dist",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "plate-app",
   "version": "1.0.0",
   "description": "Vite React app with Express backend",
+  "main": "backend/server.js",
   "scripts": {
     "build": "./build.sh",
     "start": "cd backend && npm start",
-    "dev": "cd frontend && npm run dev"
+    "dev": "cd frontend && npm run dev",
+    "postbuild": "echo 'Build completed. Backend will serve frontend from dist folder.'"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,9 @@ services:
   - type: web
     name: plate-app
     env: node
-    buildCommand: ./build.sh
-    startCommand: cd backend && npm start
+    region: oregon
+    buildCommand: chmod +x ./build.sh && ./build.sh
+    startCommand: npm start
     envVars:
       - key: VITE_API_URL
         sync: false


### PR DESCRIPTION
Configure Render deployment to correctly start the backend server and serve the built frontend.

The deployment logs showed Render was running `cd frontend && npm start` despite `render.yaml` specifying the backend. This PR explicitly configures the build and start commands, updates port binding, and adds build verification to ensure the backend serves the production frontend as intended.

---

[Open in Web](https://www.cursor.com/agents?id=bc-aa59148a-6120-4361-9ab8-10bda06bd15f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-aa59148a-6120-4361-9ab8-10bda06bd15f)